### PR TITLE
Provide missing parameter in call to mysqli_error

### DIFF
--- a/scripts/map_functions.inc
+++ b/scripts/map_functions.inc
@@ -695,7 +695,7 @@ function load_Nodes($whereClause = null, $orderBy = null)
             ($orderBy ? $orderBy : " ORDER BY node");
         // Retrieve the data
         $node_info_db = mysqli_query($GLOBALS['sql_connection'], $query)
-        or die('Could not Select Items from Node Table: ' . mysqli_error());
+        or die('Could not Select Items from Node Table: ' . mysqli_error($GLOBALS['sql_connection']));
         // Load the data into an array for ease of handling
         while ($node_info = mysqli_fetch_array($node_info_db, MYSQLI_ASSOC))
         {


### PR DESCRIPTION
Ran into an unhandled exception here because that function was expecting a parameter.  This should output what exactly went wrong.